### PR TITLE
2-1 配列描画

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,6 @@ export default function App() {
       <div className="space-y-2" role="list">
         {todos.map((t) => (
           <TodoItem
-            itemId={t.id}
             inputId={`todo-item-${t.id}`}
             title={t.title}
             completed={t.completed}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,8 +30,8 @@ export default function App() {
             inputId={`todo-item-${t.id}`}
             title={t.title}
             completed={t.completed}
-            onToggle={handleToggle}
-            onDelete={handleDelete}
+            onToggle={(completed) => handleToggle(t.id, completed)}
+            onDelete={() => handleDelete(t.id)}
           />
         ))}
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ export default function App() {
       <div className="space-y-2" role="list">
         {todos.map((t) => (
           <TodoItem
-            inputId={`todo-item-${t.id}`}
+            id={t.id}
             title={t.title}
             completed={t.completed}
             onToggle={(completed) => handleToggle(t.id, completed)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,39 @@
 import { useState } from "react";
 import TodoItem from "./components/TodoItem";
 
+type Todo = { id: string; title: string; completed: boolean };
+
 export default function App() {
-  const [todo, setTodo] = useState({
-    id: "1",
-    title: "Build TodoItem skeleton",
-    completed: false,
-  });
+  const [todos, setTodos] = useState<Todo[]>([
+    { id: "1", title: "Build TodoItem skeleton", completed: false },
+    { id: "2", title: "Wire callbacks", completed: true },
+    { id: "3", title: "Render with map()", completed: false },
+  ]);
+
+  const handleToggle = (id: string, nextCompleted: boolean) => {
+    setTodos((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, completed: nextCompleted } : t))
+    );
+  };
+
+  const handleDelete = (id: string) => {
+    setTodos((prev) => prev.filter((t) => t.id !== id));
+  };
 
   return (
     <main className="max-w-xl mx-auto p-4">
       <h1 className="text-xl font-semibold mb-3">Todo</h1>
       <div className="space-y-2" role="list">
-        <TodoItem
-          id={`todo-item-${todo.id}`}
-          title={todo.title}
-          completed={todo.completed}
-          onToggle={(nextCompleted) => {
-            console.log("toggle", todo.id, "->", nextCompleted);
-            setTodo((prev) => ({ ...prev, completed: nextCompleted }));
-          }}
-          onDelete={() => console.log("delete", todo.id)}
-        />
+        {todos.map((t) => (
+          <TodoItem
+            itemId={t.id}
+            inputId={`todo-item-${t.id}`}
+            title={t.title}
+            completed={t.completed}
+            onToggle={handleToggle}
+            onDelete={handleDelete}
+          />
+        ))}
       </div>
     </main>
   );

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,15 +1,17 @@
 import { cn } from "../lib/cn";
 
 type TodoItemProps = {
-  id: string;
+  itemId: string;
+  inputId: string;
   title: string;
   completed: boolean;
-  onToggle: (completed: boolean) => void;
-  onDelete: () => void;
+  onToggle: (id: string, completed: boolean) => void;
+  onDelete: (id: string) => void;
 };
 
 export default function TodoItem({
-  id,
+  itemId,
+  inputId,
   title,
   completed,
   onToggle,
@@ -21,14 +23,14 @@ export default function TodoItem({
       role="listitem"
     >
       <input
-        id={id}
+        id={inputId}
         type="checkbox"
         checked={completed}
-        onChange={(e) => onToggle(e.target.checked)}
+        onChange={(e) => onToggle(itemId, e.target.checked)}
         className="h-4 w-4 focus-visible:outline-1 focus-visible:outline-blue-600"
       />
       <label
-        htmlFor={id}
+        htmlFor={inputId}
         className={cn(
           "flex-1 text-sm md:text-base",
           completed && "line-through text-gray-400 opacity-60"
@@ -38,7 +40,7 @@ export default function TodoItem({
       </label>
       <button
         type="button"
-        onClick={onDelete}
+        onClick={() => onDelete(itemId)}
         aria-label="Delete todo"
         className="text-sm px-2 py-1 rounded-md border hover:bg-gray-100 dark:hover:bg-gray-700 focus-visible:outline-1 focus-visible:outline-blue-600"
       >

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -5,8 +5,8 @@ type TodoItemProps = {
   inputId: string;
   title: string;
   completed: boolean;
-  onToggle: (id: string, completed: boolean) => void;
-  onDelete: (id: string) => void;
+  onToggle: (completed: boolean) => void;
+  onDelete: () => void;
 };
 
 export default function TodoItem({
@@ -26,7 +26,7 @@ export default function TodoItem({
         id={inputId}
         type="checkbox"
         checked={completed}
-        onChange={(e) => onToggle(itemId, e.target.checked)}
+        onChange={(e) => onToggle(e.target.checked)}
         className="h-4 w-4 focus-visible:outline-1 focus-visible:outline-blue-600"
       />
       <label
@@ -40,7 +40,7 @@ export default function TodoItem({
       </label>
       <button
         type="button"
-        onClick={() => onDelete(itemId)}
+        onClick={() => onDelete()}
         aria-label="Delete todo"
         className="text-sm px-2 py-1 rounded-md border hover:bg-gray-100 dark:hover:bg-gray-700 focus-visible:outline-1 focus-visible:outline-blue-600"
       >

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,7 +1,6 @@
 import { cn } from "../lib/cn";
 
 type TodoItemProps = {
-  itemId: string;
   inputId: string;
   title: string;
   completed: boolean;
@@ -10,7 +9,6 @@ type TodoItemProps = {
 };
 
 export default function TodoItem({
-  itemId,
   inputId,
   title,
   completed,

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,7 +1,7 @@
 import { cn } from "../lib/cn";
 
 type TodoItemProps = {
-  inputId: string;
+  id: string;
   title: string;
   completed: boolean;
   onToggle: (completed: boolean) => void;
@@ -9,26 +9,28 @@ type TodoItemProps = {
 };
 
 export default function TodoItem({
-  inputId,
+  id,
   title,
   completed,
   onToggle,
   onDelete,
 }: TodoItemProps) {
+  const htmlId = `todo-item-${id}`;
+
   return (
     <div
       className="flex items-center gap-3 px-3 py-2 rounded-lg border hover:bg-gray-300 dark:hover:bg-gray-800"
       role="listitem"
     >
       <input
-        id={inputId}
+        id={htmlId}
         type="checkbox"
         checked={completed}
         onChange={(e) => onToggle(e.target.checked)}
         className="h-4 w-4 focus-visible:outline-1 focus-visible:outline-blue-600"
       />
       <label
-        htmlFor={inputId}
+        htmlFor={htmlId}
         className={cn(
           "flex-1 text-sm md:text-base",
           completed && "line-through text-gray-400 opacity-60"

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -15,7 +15,7 @@ export default function TodoItem({
   onToggle,
   onDelete,
 }: TodoItemProps) {
-  const htmlId = `todo-item-${id}`;
+  const inputId = `todo-item-${id}`;
 
   return (
     <div
@@ -23,14 +23,14 @@ export default function TodoItem({
       role="listitem"
     >
       <input
-        id={htmlId}
+        id={inputId}
         type="checkbox"
         checked={completed}
         onChange={(e) => onToggle(e.target.checked)}
         className="h-4 w-4 focus-visible:outline-1 focus-visible:outline-blue-600"
       />
       <label
-        htmlFor={htmlId}
+        htmlFor={inputId}
         className={cn(
           "flex-1 text-sm md:text-base",
           completed && "line-through text-gray-400 opacity-60"


### PR DESCRIPTION
**概要**

- 2-1（配列描画） を実装

- App の state を Todo 配列に変更

- todos.map(...) で TodoItem を複数描画するように変更

**変更点**

- イベント処理

　- handleToggle: 指定 ID の completed 状態を更新する処理を追加

　- handleDelete: 指定 ID を filter で除外する処理を追加

　- 子コンポーネントの props を (id, completed) / (id) 形式に変更し、無名関数を使わず直接渡せる形に変更

- id 命名

　- データ ID と DOM input 用 ID が曖昧だったため整理

　- DOM 用 id を inputId に変更、データ ID は itemId に統一

| Before | After |
|--------|-------|
| <img width="453" height="422" alt="スクリーンショット 2025-08-26 175739" src="https://github.com/user-attachments/assets/e6b3fa92-ceeb-47df-af67-7ae87d69b5df" /> | <img width="407" height="366" alt="スクリーンショット 2025-08-28 105213" src="https://github.com/user-attachments/assets/43f533f9-6afa-438f-b05e-988e2b9dfc0f" />


