### PR TITLE
feat(composer): add empty validation and error message

### DIFF
--- a/src/components/TodoComposer.tsx
+++ b/src/components/TodoComposer.tsx
@@ -2,13 +2,23 @@ import { useState } from "react";
 
 export default function TodoComposer() {
   const [title, setTitle] = useState("");
+  const [error, setError] = useState("");
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = title.trim();
-    if (!trimmed) return;
+    if (!trimmed) {
+      setError("Task cannot be empty");
+      return;
+    }
+    if (trimmed.length < 3) {
+      setError("Task must be at least 3 characters long");
+      return;
+    }
+
     console.log("[TodoComposer] add:", trimmed);
     setTitle("");
+    setError("");
   };
 
   return (
@@ -20,6 +30,11 @@ export default function TodoComposer() {
         aria-label="Add a task"
         className="w-full rounded-md border px-3 py-2 focus-visible:outline-1 focus-visible:outline-blue-600 focus-visible:outline-offset-2"
       />
+      {error && (
+        <p className="mt-1 text-sm text-red-600" role="alert">
+          {error}
+        </p>
+      )}
     </form>
   );
 }


### PR DESCRIPTION
**Summary**
Implemented input validation in `TodoComposer`:
- Empty input is not allowed
- Error message is displayed when validation fails
- (Optional) Added minimum length check

**Changes**
- Added `error` state to handle validation messages
- Updated `handleSubmit` to include validation logic

**When  entering 3 characters or fewer**
| Before | After |
|--------|-------|
|<img width="564" height="502" alt="スクリーンショット 2025-09-04 101023" src="https://github.com/user-attachments/assets/3e04f610-4ce0-4e6a-8989-c9b52896366d" />|<img width="409" height="454" alt="スクリーンショット 2025-09-04 101245" src="https://github.com/user-attachments/assets/65fbb9f5-558e-4471-8e88-31341c2bf49f" />

**When entering empty**
| Before Enter | After push Enter|
|--------|-------|
|<img width="529" height="583" alt="スクリーンショット 2025-09-04 101137" src="https://github.com/user-attachments/assets/0c367fb9-44e1-4e7d-ba41-e235ca20c514" />|<img width="417" height="470" alt="スクリーンショット 2025-09-04 101256" src="https://github.com/user-attachments/assets/c3e4f04e-45ab-4213-b5c5-d895d6168831" />

