### PR TITLE
Todo型追加、App.tsxのTodoを型参照に置き換え

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,9 +28,7 @@ export default function App() {
       <div className="space-y-2" role="list">
         {todos.map((t) => (
           <TodoItem
-            id={t.id}
-            title={t.title}
-            completed={t.completed}
+            todo={t}
             onToggle={(completed) => handleToggle(t.id, completed)}
             onDelete={() => handleDelete(t.id)}
           />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import TodoItem from "./components/TodoItem";
 import TodoComposer from "./components/TodoComposer";
 
-type Todo = { id: string; title: string; completed: boolean };
+import type { Todo } from "./types/todo";
 
 export default function App() {
   const [todos, setTodos] = useState<Todo[]>([

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,21 +1,14 @@
 import { cn } from "../lib/cn";
+import type { Todo } from "../types/todo";
 
-type TodoItemProps = {
-  id: string;
-  title: string;
-  completed: boolean;
+export type TodoItemProps = {
+  todo: Todo;
   onToggle: (completed: boolean) => void;
   onDelete: () => void;
 };
 
-export default function TodoItem({
-  id,
-  title,
-  completed,
-  onToggle,
-  onDelete,
-}: TodoItemProps) {
-  const inputId = `todo-item-${id}`;
+export default function TodoItem({ todo, onToggle, onDelete }: TodoItemProps) {
+  const inputId = `todo-item-${todo.id}`;
 
   return (
     <div
@@ -25,7 +18,7 @@ export default function TodoItem({
       <input
         id={inputId}
         type="checkbox"
-        checked={completed}
+        checked={todo.completed}
         onChange={(e) => onToggle(e.target.checked)}
         className="h-4 w-4 focus-visible:outline-1 focus-visible:outline-blue-600"
       />
@@ -33,10 +26,10 @@ export default function TodoItem({
         htmlFor={inputId}
         className={cn(
           "flex-1 text-sm",
-          completed && "line-through text-gray-400 opacity-60"
+          todo.completed && "line-through text-gray-400 opacity-60"
         )}
       >
-        {title}
+        {todo.title}
       </label>
       <button
         type="button"

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -1,7 +1,5 @@
-export type TodoId = string;
-
 export type Todo = {
-  id: TodoId;
+  id: string;
   title: string;
   completed: boolean;
 };

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -1,0 +1,7 @@
+export type TodoId = string;
+
+export type Todo = {
+  id: TodoId;
+  title: string;
+  completed: boolean;
+};


### PR DESCRIPTION
スコープ：Todoの型を追加し、App.tsx の Todo を型ファイル参照に置き換え（挙動変更なし）。
理由：実装前に契約（型）を固定し、単一情報源化で今後の変更を容易に。
変更：src/types/todo.ts 追加、src/App.tsx の型参照差し替え。
スコープ外：reducer/hydrate 実装・UI変更なし。