### PR TITLE
complete TodoComposer and integrate with App (useState)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,15 @@ export default function App() {
     { id: "3", title: "Render with map()", completed: false },
   ]);
 
+  const handleAdd = (title: string) => {
+    const newTodo: Todo = {
+      id: crypto.randomUUID(),
+      title,
+      completed: false,
+    };
+    setTodos((prev) => [newTodo, ...prev]);
+  };
+
   const handleToggle = (id: string, nextCompleted: boolean) => {
     setTodos((prev) =>
       prev.map((t) => (t.id === id ? { ...t, completed: nextCompleted } : t))
@@ -24,7 +33,7 @@ export default function App() {
   return (
     <main className="max-w-xl mx-auto p-4">
       <h1 className="text-xl font-semibold mb-3">Todo</h1>
-      <TodoComposer />
+      <TodoComposer onAdd={handleAdd} />
       <div className="space-y-2" role="list">
         {todos.map((t) => (
           <TodoItem

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ export default function App() {
       <div className="space-y-2" role="list">
         {todos.map((t) => (
           <TodoItem
+            key={t.id}
             todo={t}
             onToggle={(completed) => handleToggle(t.id, completed)}
             onDelete={() => handleDelete(t.id)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ export default function App() {
   };
 
   return (
-    <main className="max-w-xl mx-auto p-4">
+    <main className="w-[480px] mx-auto p-4">
       <h1 className="text-xl font-semibold mb-3">Todo</h1>
       <TodoComposer onAdd={handleAdd} />
       <div className="space-y-2" role="list">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,9 +6,13 @@ import type { Todo } from "./types/todo";
 
 export default function App() {
   const [todos, setTodos] = useState<Todo[]>([
-    { id: "1", title: "Build TodoItem skeleton", completed: false },
-    { id: "2", title: "Wire callbacks", completed: true },
-    { id: "3", title: "Render with map()", completed: false },
+    {
+      id: crypto.randomUUID(),
+      title: "Build TodoItem skeleton",
+      completed: false,
+    },
+    { id: crypto.randomUUID(), title: "Wire callbacks", completed: true },
+    { id: crypto.randomUUID(), title: "Render with map()", completed: false },
   ]);
 
   const handleAdd = (title: string) => {

--- a/src/components/TodoComposer.tsx
+++ b/src/components/TodoComposer.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 
-export default function TodoComposer() {
+type Props = {
+  onAdd: (title: string) => void;
+};
+
+export default function TodoComposer({ onAdd }: Props) {
   const [title, setTitle] = useState("");
   const [error, setError] = useState("");
 
@@ -16,7 +20,7 @@ export default function TodoComposer() {
       return;
     }
 
-    console.log("[TodoComposer] add:", trimmed);
+    onAdd(trimmed);
     setTitle("");
     setError("");
   };
@@ -25,7 +29,10 @@ export default function TodoComposer() {
     <form onSubmit={handleSubmit} className="mb-3">
       <input
         value={title}
-        onChange={(e) => setTitle(e.target.value)}
+        onChange={(e) => {
+          setTitle(e.target.value);
+          if (error) setError("");
+        }}
         placeholder="Add a new task"
         aria-label="Add a task"
         className="w-full rounded-md border px-3 py-2 focus-visible:outline-1 focus-visible:outline-blue-600 focus-visible:outline-offset-2"

--- a/src/components/TodoComposer.tsx
+++ b/src/components/TodoComposer.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { validateTitle } from "../lib/validateTodo";
 
 type Props = {
   onAdd: (title: string) => void;
@@ -6,23 +7,20 @@ type Props = {
 
 export default function TodoComposer({ onAdd }: Props) {
   const [title, setTitle] = useState("");
-  const [error, setError] = useState("");
+  const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const trimmed = title.trim();
-    if (!trimmed) {
-      setError("Task cannot be empty");
-      return;
-    }
-    if (trimmed.length < 3) {
-      setError("Task must be at least 3 characters long");
+
+    const err = validateTitle(title);
+    if (err) {
+      setError(err);
       return;
     }
 
-    onAdd(trimmed);
+    onAdd(title.trim());
     setTitle("");
-    setError("");
+    setError(null);
   };
 
   return (
@@ -31,7 +29,7 @@ export default function TodoComposer({ onAdd }: Props) {
         value={title}
         onChange={(e) => {
           setTitle(e.target.value);
-          if (error) setError("");
+          if (error) setError(null);
         }}
         placeholder="Add a new task"
         aria-label="Add a task"

--- a/src/components/TodoComposer.tsx
+++ b/src/components/TodoComposer.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { validateTitle } from "../lib/validateTodo";
+import { getTitleValidationError } from "../lib/validateTodo";
 
 type Props = {
   onAdd: (title: string) => void;
@@ -12,7 +12,7 @@ export default function TodoComposer({ onAdd }: Props) {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    const err = validateTitle(title);
+    const err = getTitleValidationError(title);
     if (err) {
       setError(err);
       return;

--- a/src/components/TodoComposer.tsx
+++ b/src/components/TodoComposer.tsx
@@ -12,11 +12,12 @@ export default function TodoComposer({ onAdd }: Props) {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    const err = getTitleValidationError(title);
+    const trimmed = title.trim();
+    const err = getTitleValidationError(trimmed);
     setError(err);
 
     if (!err) {
-      onAdd(title.trim());
+      onAdd(trimmed);
       setTitle("");
     }
   };

--- a/src/components/TodoComposer.tsx
+++ b/src/components/TodoComposer.tsx
@@ -13,14 +13,12 @@ export default function TodoComposer({ onAdd }: Props) {
     e.preventDefault();
 
     const err = getTitleValidationError(title);
-    if (err) {
-      setError(err);
-      return;
-    }
+    setError(err);
 
-    onAdd(title.trim());
-    setTitle("");
-    setError(null);
+    if (!err) {
+      onAdd(title.trim());
+      setTitle("");
+    }
   };
 
   return (

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -25,7 +25,7 @@ export default function TodoItem({ todo, onToggle, onDelete }: TodoItemProps) {
       <label
         htmlFor={inputId}
         className={cn(
-          "flex-1 text-sm",
+          "flex-1 min-w-0 text-sm break-words",
           todo.completed && "line-through text-gray-400 opacity-60"
         )}
       >

--- a/src/lib/validateTodo.ts
+++ b/src/lib/validateTodo.ts
@@ -1,0 +1,6 @@
+export function validateTitle(raw: string): string | null {
+  const s = raw.trim();
+  if (!s) return "Task cannot be empty";
+  if (s.length < 3) return "Task must be at least 3 characters long";
+  return null;
+}

--- a/src/lib/validateTodo.ts
+++ b/src/lib/validateTodo.ts
@@ -1,5 +1,5 @@
-export function getTitleValidationError(raw: string): string | null {
-  const s = raw.trim();
+export function getTitleValidationError(title: string): string | null {
+  const s = title.trim();
   if (!s) return "Task cannot be empty";
   if (s.length < 3) return "Task must be at least 3 characters long";
   return null;

--- a/src/lib/validateTodo.ts
+++ b/src/lib/validateTodo.ts
@@ -1,4 +1,4 @@
-export function validateTitle(raw: string): string | null {
+export function getTitleValidationError(raw: string): string | null {
   const s = raw.trim();
   if (!s) return "Task cannot be empty";
   if (s.length < 3) return "Task must be at least 3 characters long";


### PR DESCRIPTION
**概要**

- TodoComposer コンポーネントを完成させ、App に接続しました。

- 新規タスクの追加が可能になり、Todoアプリの基本操作（追加・切替・削除）が一通り揃いました。

**変更点**

TodoComposer

- props onAdd を追加し、入力値を親に渡せるように変更

- 入力値のバリデーション（空文字禁止・3文字未満禁止）

- 入力エラー時のメッセージ表示

App

- handleAdd を実装（crypto.randomUUID() で一意ID生成、配列先頭に追加）

- TodoComposer を onAdd={handleAdd} で接続

**新規タスク追加時**
| Before | After |
|--------|-------|
|<img width="1057" height="526" alt="スクリーンショット 2025-09-10 135215" src="https://github.com/user-attachments/assets/fafbe4e2-4cca-4bb2-9d69-4fbe0ef8ba33" />|<img width="1059" height="487" alt="スクリーンショット 2025-09-10 135636" src="https://github.com/user-attachments/assets/9cf6d278-2b7f-452a-a6f5-7f8c914b9067" />
