### PR TITLE
feature/5-1-filter-tabs-ui-2

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import TodoItem from "./components/TodoItem";
 import TodoComposer from "./components/TodoComposer";
 import FilterTabs from "./components/FilterTabs";
-
+import { applyFilter, countByFilter } from "./utils/filters";
 import type { Todo } from "./types/todo";
 import type { FilterTab } from "./types/filter";
 
@@ -38,17 +38,8 @@ export default function App() {
     setTodos((prev) => prev.filter((t) => t.id !== id));
   };
 
-  const visibleTodos = todos.filter((t) => {
-    if (filter === "active") return !t.completed;
-    if (filter === "completed") return t.completed;
-    return true;
-  });
-
-  const counts = {
-    all: todos.length,
-    active: todos.filter((t) => !t.completed).length,
-    completed: todos.filter((t) => t.completed).length,
-  };
+  const counts = countByFilter(todos);
+  const filteredTodos = applyFilter(todos, filter);
 
   return (
     <main className="w-[480px] mx-auto p-4">
@@ -62,7 +53,7 @@ export default function App() {
       </div>
       <TodoComposer onAdd={handleAdd} />
       <div className="space-y-2" role="list">
-        {visibleTodos.map((t) => (
+        {filteredTodos.map((t) => (
           <TodoItem
             key={t.id}
             todo={t}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ export default function App() {
         />
       </div>
       <TodoComposer onAdd={handleAdd} />
-      <div className="space-y-2" role="list">
+      <div className="space-y-2 h-80 overflow-auto" role="list">
         {filteredTodos.map((t) => (
           <TodoItem
             key={t.id}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import TodoItem from "./components/TodoItem";
 import TodoComposer from "./components/TodoComposer";
+import FilterTabs from "./components/FilterTabs";
 
 import type { Todo } from "./types/todo";
+import type { FilterTab } from "./types/filter";
 
 export default function App() {
   const [todos, setTodos] = useState<Todo[]>([
@@ -14,6 +16,8 @@ export default function App() {
     { id: crypto.randomUUID(), title: "Wire callbacks", completed: true },
     { id: crypto.randomUUID(), title: "Render with map()", completed: false },
   ]);
+
+  const [filter, setFilter] = useState<FilterTab>("all");
 
   const handleAdd = (title: string) => {
     const newTodo: Todo = {
@@ -34,12 +38,31 @@ export default function App() {
     setTodos((prev) => prev.filter((t) => t.id !== id));
   };
 
+  const visibleTodos = todos.filter((t) => {
+    if (filter === "active") return !t.completed;
+    if (filter === "completed") return t.completed;
+    return true;
+  });
+
+  const counts = {
+    all: todos.length,
+    active: todos.filter((t) => !t.completed).length,
+    completed: todos.filter((t) => t.completed).length,
+  };
+
   return (
     <main className="w-[480px] mx-auto p-4">
       <h1 className="text-xl font-semibold mb-3">Todo</h1>
+      <div className="mb-3">
+        <FilterTabs
+          active={filter}
+          onChange={(next) => setFilter(next)}
+          counts={counts}
+        />
+      </div>
       <TodoComposer onAdd={handleAdd} />
       <div className="space-y-2" role="list">
-        {todos.map((t) => (
+        {visibleTodos.map((t) => (
           <TodoItem
             key={t.id}
             todo={t}

--- a/src/components/FilterTabs.tsx
+++ b/src/components/FilterTabs.tsx
@@ -23,7 +23,7 @@ export default function FilterTabs({ active, onChange, counts }: Props) {
         const badge = counts ? counts[key] : undefined;
 
         return (
-          <div key={key} className="relative">
+          <div key={key}>
             <input
               id={`filter-${key}`}
               type="radio"
@@ -47,9 +47,7 @@ export default function FilterTabs({ active, onChange, counts }: Props) {
               {badge !== undefined && (
                 <span
                   className={cn(
-                    "badge ml-2 inline-block min-w-6 px-1.5 text-center text-xs rounded-lg",
-                    "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200",
-                    "badge ml-2 inline-block min-w-6 px-1.5 text-center text-xs rounded-lg",
+                    "ml-2 inline-block min-w-[1.5rem] px-1.5 text-center text-xs rounded-lg",
                     isActive
                       ? "bg-blue-600 text-white"
                       : "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200"

--- a/src/components/FilterTabs.tsx
+++ b/src/components/FilterTabs.tsx
@@ -15,45 +15,51 @@ const TABS: { key: FilterTab; label: string }[] = [
 
 export default function FilterTabs({ active, onChange, counts }: Props) {
   return (
-    <div aria-label="Filter todos" className="flex items-center gap-2">
+    <fieldset className="flex items-center gap-2">
+      <legend className="sr-only">Filter todos</legend>
+
       {TABS.map(({ key, label }) => {
-        const isActive = key === active;
         const badge =
           counts && typeof counts[key] === "number" ? counts[key] : undefined;
 
         return (
-          <button
-            key={key}
-            type="button"
-            aria-pressed={isActive}
-            onClick={() => onChange(key)}
-            className={cn(
-              "px-3 py-1.5 rounded-xl ring-1 transition-colors text-sm",
-              "focus-visible:outline-1 focus-visible:outline-blue-600",
-              "ring-gray-200 hover:bg-gray-50 hover:ring-gray-300",
-              "dark:hover:bg-gray-800",
-              isActive
-                ? "bg-gray-100 ring-gray-300 text-gray-900 dark:bg-gray-800 dark:text-gray-100"
-                : "bg-white text-gray-700 dark:bg-transparent dark:text-gray-300"
-            )}
-          >
-            <span>{label}</span>
-            {typeof badge === "number" && (
-              <span
-                className={cn(
-                  "ml-2 inline-block min-w-6 px-1.5 text-center text-xs rounded-lg",
-                  isActive
-                    ? "bg-blue-600 text-white"
-                    : "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
-                )}
-                aria-hidden="true"
-              >
-                {badge}
-              </span>
-            )}
-          </button>
+          <div key={key} className="relative">
+            <input
+              id={`filter-${key}`}
+              type="radio"
+              name="todo-filter"
+              value={key}
+              checked={active === key}
+              onChange={() => onChange(key)}
+              className="peer sr-only"
+            />
+            <label
+              htmlFor={`filter-${key}`}
+              className={cn(
+                "px-3 py-1.5 rounded-xl ring-1 transition-colors text-sm cursor-pointer select-none",
+                "ring-gray-200 hover:bg-gray-50 hover:ring-gray-300 dark:hover:bg-gray-800",
+                "peer-focus-visible:outline-1 peer-focus-visible:outline-blue-600",
+                "peer-checked:bg-gray-100 peer-checked:ring-gray-300 peer-checked:text-gray-900",
+                "bg-white text-gray-700 dark:bg-transparent dark:text-gray-300 dark:peer-checked:text-gray-100"
+              )}
+            >
+              <span>{label}</span>
+              {typeof badge === "number" && (
+                <span
+                  className={cn(
+                    "ml-2 inline-block min-w-6 px-1.5 text-center text-xs rounded-lg",
+                    "peer-checked:bg-blue-600 peer-checked:text-white",
+                    "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+                  )}
+                  aria-hidden="true"
+                >
+                  {badge}
+                </span>
+              )}
+            </label>
+          </div>
         );
       })}
-    </div>
+    </fieldset>
   );
 }

--- a/src/components/FilterTabs.tsx
+++ b/src/components/FilterTabs.tsx
@@ -20,7 +20,7 @@ export default function FilterTabs({ active, onChange, counts }: Props) {
 
       {TABS.map(({ key, label }) => {
         const isActive = active === key;
-        const badge = counts ? counts[key] : undefined;
+        const badge = counts?.[key];
 
         return (
           <div key={key}>

--- a/src/components/FilterTabs.tsx
+++ b/src/components/FilterTabs.tsx
@@ -19,6 +19,7 @@ export default function FilterTabs({ active, onChange, counts }: Props) {
       <legend className="sr-only">Filter todos</legend>
 
       {TABS.map(({ key, label }) => {
+        const isActive = active === key;
         const badge =
           counts && typeof counts[key] === "number" ? counts[key] : undefined;
 
@@ -29,7 +30,7 @@ export default function FilterTabs({ active, onChange, counts }: Props) {
               type="radio"
               name="todo-filter"
               value={key}
-              checked={active === key}
+              checked={isActive}
               onChange={() => onChange(key)}
               className="peer sr-only"
             />
@@ -47,9 +48,12 @@ export default function FilterTabs({ active, onChange, counts }: Props) {
               {typeof badge === "number" && (
                 <span
                   className={cn(
-                    "ml-2 inline-block min-w-6 px-1.5 text-center text-xs rounded-lg",
-                    "peer-checked:bg-blue-600 peer-checked:text-white",
-                    "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+                    "badge ml-2 inline-block min-w-6 px-1.5 text-center text-xs rounded-lg",
+                    "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200",
+                    "badge ml-2 inline-block min-w-6 px-1.5 text-center text-xs rounded-lg",
+                    isActive
+                      ? "bg-blue-600 text-white"
+                      : "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
                   )}
                   aria-hidden="true"
                 >

--- a/src/components/FilterTabs.tsx
+++ b/src/components/FilterTabs.tsx
@@ -1,10 +1,10 @@
 import { cn } from "../lib/cn";
-import type { FilterTab } from "../types/filter";
+import type { FilterCounts, FilterTab } from "../types/filter";
 
 type Props = {
   active: FilterTab;
   onChange: (next: FilterTab) => void;
-  counts?: { all: number; active: number; completed: number };
+  counts?: FilterCounts;
 };
 
 const TABS: { key: FilterTab; label: string }[] = [
@@ -20,8 +20,7 @@ export default function FilterTabs({ active, onChange, counts }: Props) {
 
       {TABS.map(({ key, label }) => {
         const isActive = active === key;
-        const badge =
-          counts && typeof counts[key] === "number" ? counts[key] : undefined;
+        const badge = counts ? counts[key] : undefined;
 
         return (
           <div key={key} className="relative">
@@ -45,7 +44,7 @@ export default function FilterTabs({ active, onChange, counts }: Props) {
               )}
             >
               <span>{label}</span>
-              {typeof badge === "number" && (
+              {badge !== undefined && (
                 <span
                   className={cn(
                     "badge ml-2 inline-block min-w-6 px-1.5 text-center text-xs rounded-lg",

--- a/src/components/FilterTabs.tsx
+++ b/src/components/FilterTabs.tsx
@@ -1,5 +1,5 @@
 import { cn } from "../lib/cn";
-import type { FilterCounts, FilterTab } from "../types/filter";
+import { FilterTab, type FilterCounts } from "../types/filter";
 
 type Props = {
   active: FilterTab;
@@ -8,9 +8,9 @@ type Props = {
 };
 
 const TABS: { key: FilterTab; label: string }[] = [
-  { key: "all", label: "ALL" },
-  { key: "active", label: "Active" },
-  { key: "completed", label: "Completed" },
+  { key: FilterTab.All, label: "ALL" },
+  { key: FilterTab.Active, label: "Active" },
+  { key: FilterTab.Completed, label: "Completed" },
 ];
 
 export default function FilterTabs({ active, onChange, counts }: Props) {

--- a/src/components/FilterTabs.tsx
+++ b/src/components/FilterTabs.tsx
@@ -1,0 +1,62 @@
+import { cn } from "../lib/cn";
+import type { FilterTab } from "../types/filter";
+
+type Props = {
+  active: FilterTab;
+  onChange: (next: FilterTab) => void;
+  counts?: { all: number; active: number; completed: number };
+};
+
+const TABS: { key: FilterTab; label: string }[] = [
+  { key: "all", label: "ALL" },
+  { key: "active", label: "Active" },
+  { key: "completed", label: "Completed" },
+];
+
+export default function FilterTabs({ active, onChange, counts }: Props) {
+  return (
+    <div aria-label="Filter todos" className="flex items-center gap-2">
+      {TABS.map(({ key, label }) => {
+        const isActive = key === active;
+        const badge =
+          counts && typeof counts[key] === "number" ? counts[key] : undefined;
+
+        return (
+          <button
+            key={key}
+            type="button"
+            aria-pressed={isActive}
+            aria-label={`${label}${
+              typeof badge === "number" ? ` (${badge})` : ""
+            }`}
+            onClick={() => onChange(key)}
+            className={cn(
+              "px-3 py-1.5 rounded-xl ring-1 transition-colors text-sm",
+              "focus-visible:outline-1 focus-visible:outline-blue-600",
+              "ring-gray-200 hover:bg-gray-50 hover:ring-gray-300",
+              "dark:hover:bg-gray-800",
+              isActive
+                ? "bg-gray-100 ring-gray-300 text-gray-900 dark:bg-gray-800 dark:text-gray-100"
+                : "bg-white text-gray-700 dark:bg-transparent dark:text-gray-300"
+            )}
+          >
+            <span>{label}</span>
+            {typeof badge === "number" && (
+              <span
+                className={cn(
+                  "ml-2 inline-block min-w-6 px-1.5 text-center text-xs rounded-lg",
+                  isActive
+                    ? "bg-blue-600 text-white"
+                    : "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+                )}
+                aria-hidden="true"
+              >
+                {badge}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/FilterTabs.tsx
+++ b/src/components/FilterTabs.tsx
@@ -26,9 +26,6 @@ export default function FilterTabs({ active, onChange, counts }: Props) {
             key={key}
             type="button"
             aria-pressed={isActive}
-            aria-label={`${label}${
-              typeof badge === "number" ? ` (${badge})` : ""
-            }`}
             onClick={() => onChange(key)}
             className={cn(
               "px-3 py-1.5 rounded-xl ring-1 transition-colors text-sm",

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -1,0 +1,2 @@
+export const FILTER_TABS = ["all", "active", "completed"] as const;
+export type FilterTab = typeof FILTER_TABS[number];

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -1,2 +1,1 @@
-export const FILTER_TABS = ["all", "active", "completed"] as const;
-export type FilterTab = typeof FILTER_TABS[number];
+export type FilterTab = "all" | "active" | "completed";

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -1,4 +1,10 @@
-export type FilterTab = "all" | "active" | "completed";
+export const FilterTab = {
+  All: "all",
+  Active: "active",
+  Completed: "completed",
+} as const;
+
+export type FilterTab = (typeof FilterTab)[keyof typeof FilterTab];
 
 export type FilterCounts = {
   all: number;

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -1,1 +1,7 @@
 export type FilterTab = "all" | "active" | "completed";
+
+export type FilterCounts = {
+  all: number;
+  active: number;
+  completed: number;
+};

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -1,0 +1,20 @@
+import type { FilterTab } from "../types/filter";
+import type { Todo } from "../types/todo";
+
+export function applyFilter(todos: Todo[], tab: FilterTab): Todo[] {
+  switch (tab) {
+    case "active":
+      return todos.filter((t) => !t.completed);
+    case "completed":
+      return todos.filter((t) => t.completed);
+    case "all":
+      return todos;
+  }
+}
+
+export function countByFilter(todos: Todo[]) {
+  const all = todos.length;
+  const active = todos.reduce((acc, t) => acc + (t.completed ? 0 : 1), 0);
+  const completed = all - active;
+  return { all, active, completed };
+}

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -9,8 +9,6 @@ export function applyFilter(todos: Todo[], tab: FilterTab): Todo[] {
       return todos.filter((t) => t.completed);
     case FilterTab.All:
       return todos;
-    default:
-      return todos;
   }
 }
 

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -1,4 +1,4 @@
-import type { FilterTab } from "../types/filter";
+import type { FilterTab, FilterCounts } from "../types/filter";
 import type { Todo } from "../types/todo";
 
 export function applyFilter(todos: Todo[], tab: FilterTab): Todo[] {
@@ -12,7 +12,7 @@ export function applyFilter(todos: Todo[], tab: FilterTab): Todo[] {
   }
 }
 
-export function countByFilter(todos: Todo[]) {
+export function countByFilter(todos: Todo[]): FilterCounts {
   const all = todos.length;
   const active = todos.reduce((acc, t) => acc + (t.completed ? 0 : 1), 0);
   const completed = all - active;

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -1,13 +1,15 @@
-import type { FilterTab, FilterCounts } from "../types/filter";
+import { FilterTab, type FilterCounts } from "../types/filter";
 import type { Todo } from "../types/todo";
 
 export function applyFilter(todos: Todo[], tab: FilterTab): Todo[] {
   switch (tab) {
-    case "active":
+    case FilterTab.Active:
       return todos.filter((t) => !t.completed);
-    case "completed":
+    case FilterTab.Completed:
       return todos.filter((t) => t.completed);
-    case "all":
+    case FilterTab.All:
+      return todos;
+    default:
       return todos;
   }
 }


### PR DESCRIPTION
**Summary**

- FilterTabs コンポーネントを追加

- App.tsx と接続し、All / Active / Completed のフィルタ切替を実装

- 各タブに 件数（counts） を表示

- 選択状態は aria-pressed で示し、アクセシビリティに配慮
- 
**Changes**

- 新規 components/FilterTabs.tsx を追加

- types/filter.ts
`export type FilterTab = "all" | "active" | "completed";`

- utils/filters.ts を追加
applyFilter : 指定されたタブに基づいて Todo を絞り込み
countByFilter : all / active / completed の件数をまとめて算出

- active（現在のフィルタ）

- onChange（切替時のコールバック）

- counts（all / active / completed の件数表示、オプション）

**UI**
| Before | After |
|--------|-------|
|<img width="529" height="583" alt="スクリーンショット 2025-09-04 101137" src="https://github.com/user-attachments/assets/c884f376-439c-44a3-a7c2-ff1334b32372" />|<img width="540" height="427" alt="スクリーンショット 2025-09-17 140720" src="https://github.com/user-attachments/assets/9b578398-57b8-42f6-95d1-84d77be033fa" />

**active/completedを押したとき**
| active | completed |
|--------|-------|
|<img width="512" height="330" alt="スクリーンショット 2025-09-17 141839" src="https://github.com/user-attachments/assets/5eab6033-2287-4d2c-a7c1-bfd79d1752c2" />|<img width="505" height="310" alt="スクリーンショット 2025-09-17 141849" src="https://github.com/user-attachments/assets/4dc1f79e-07c4-47a4-8175-b342c1cea558" />


