### PR TITLE
feature/5-2/todo-active-counter

### DIFF
--- a/src/components/FilterTabs.tsx
+++ b/src/components/FilterTabs.tsx
@@ -14,8 +14,15 @@ const TABS: { key: FilterTab; label: string }[] = [
 ];
 
 export default function FilterTabs({ active, onChange, counts }: Props) {
+  const left = counts?.active ?? 0;
+  let leftLabel;
+  if (left === 1) {
+    leftLabel = `${left} item left`;
+  } else {
+    leftLabel = `${left} items left`;
+  }
   return (
-    <fieldset className="flex items-center gap-2">
+    <fieldset className="flex items-center gap-2 w-full">
       <legend className="sr-only">Filter todos</legend>
 
       {TABS.map(({ key, label }) => {
@@ -61,6 +68,12 @@ export default function FilterTabs({ active, onChange, counts }: Props) {
           </div>
         );
       })}
+      <span
+        aria-live="polite"
+        className="ml-auto text-sm text-gray-500 dark:text-gray-400"
+      >
+        {leftLabel}
+      </span>
     </fieldset>
   );
 }

--- a/src/components/FilterTabs.tsx
+++ b/src/components/FilterTabs.tsx
@@ -13,14 +13,20 @@ const TABS: { key: FilterTab; label: string }[] = [
   { key: FilterTab.Completed, label: "Completed" },
 ];
 
+function getLeftLabel(left: number): string {
+  if (left === 0) {
+    return "All done!";
+  }
+  if (left === 1) {
+    return "1 item left";
+  }
+  return `${left} items left`;
+}
+
 export default function FilterTabs({ active, onChange, counts }: Props) {
   const left = counts?.active ?? 0;
-  let leftLabel;
-  if (left === 1) {
-    leftLabel = `${left} item left`;
-  } else {
-    leftLabel = `${left} items left`;
-  }
+  const leftLabel = getLeftLabel(left);
+
   return (
     <fieldset className="flex items-center gap-2 w-full">
       <legend className="sr-only">Filter todos</legend>


### PR DESCRIPTION
## 概要
- FilterTabs コンポーネントに右寄せで「未完了カウンタ」を追加しました。
- `countByFilter` の戻り値を利用して未完了タスク数を表示しています。
- タスクの追加／完了切り替えに即時反映されます。

## 実装背景
- 未完了タスク数はfilterタブで確認も可能ですが、ユーザーにとって「あといくつタスクが残っているのか」が一目でわかることが重要だと捉え、追加で実装しました。

**UI**
| Before | After |
|--------|-------|
|<img width="540" height="427" alt="スクリーンショット 2025-09-17 140720" src="https://github.com/user-attachments/assets/f1569255-8be4-4fcc-b0ae-e71ed316665b" />|<img width="500" height="367" alt="スクリーンショット 2025-09-24 115502" src="https://github.com/user-attachments/assets/6ead2437-dde1-4e57-86be-7fb29e3dbe0a" />

**残り1件の場合:items→item**
<img width="517" height="275" alt="スクリーンショット 2025-09-24 115542" src="https://github.com/user-attachments/assets/22f37090-22f1-44ac-a938-f1729bb9cbf2" />

